### PR TITLE
Work on using module.exports instead of exports.

### DIFF
--- a/lib/shake.js
+++ b/lib/shake.js
@@ -1,5 +1,11 @@
 'use strict';
 
-exports.Module = require('./shake/module');
-exports.ShakeParserPlugin = require('./shake/parser-plugin');
-exports.ShakePlugin = require('./shake/plugin');
+const Module = require('./shake/module');
+const ShakeParserPlugin = require('./shake/parser-plugin');
+const ShakePlugin = require('./shake/plugin');
+
+module.exports = {
+  Module,
+  ShakeParserPlugin,
+  ShakePlugin
+};


### PR DESCRIPTION
Hello I saw on twitter you wanted to change the lib to use `module.exports` instead of `exports.name`. I have attempted to replace those in this PR I hope this saves you some time in your work.
