### PR TITLE
Avoid global bailout on `typeof require`

### DIFF
--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -455,7 +455,7 @@ Analyzer.prototype.siftNew = function siftNew(node, current) {
 };
 
 Analyzer.prototype.siftUnaryExpression = function siftUnaryExpression(node) {
-  // Mark `typeof require` and similar as a valid use of `require`
+  // Mark `typeof require` as a valid use of `require`
   const argument = node.argument;
   if (node.operator !== 'typeof' || argument.type !== 'Identifier' || argument.name !== 'require')
     return false;

--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -457,7 +457,7 @@ Analyzer.prototype.siftNew = function siftNew(node, current) {
 Analyzer.prototype.siftUnaryExpression = function siftUnaryExpression(node) {
   // Mark `typeof require` and similar as a valid use of `require`
   const argument = node.argument;
-  if (argument.type !== 'Identifier' || argument.name !== 'require')
+  if (node.operator !== 'typeof' || argument.type !== 'Identifier' || argument.name !== 'require')
     return false;
 
   if (this.requireUses.has(argument))

--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -494,6 +494,10 @@ Analyzer.prototype.siftRequireUse = function siftRequireUse(node, current) {
     return;
   this.requireUses.add(node);
 
+  // No need to bail out on eg. `typeof require`
+  if (node.parentNode.type === 'UnaryExpression')
+    return;
+
   current.bailout('Invalid use of `require`', node.loc);
   this.bailout('Invalid use of `require`', node.loc, current.resource);
 };

--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -252,7 +252,8 @@ Analyzer.prototype.sift = function sift(ast, current) {
     MemberExpression: node => this.siftMember(node, current, false),
     Identifier: node => this.siftRequireUse(node, current),
     CallExpression: node => this.siftCall(node, current),
-    NewExpression: node => this.siftNew(node, current)
+    NewExpression: node => this.siftNew(node, current),
+    UnaryExpression: node => this.siftUnaryExpression(node),
   });
 
   this.moduleUses.forEach((module, use) => {
@@ -453,6 +454,17 @@ Analyzer.prototype.siftNew = function siftNew(node, current) {
                  'info');
 };
 
+Analyzer.prototype.siftUnaryExpression = function siftUnaryExpression(node) {
+  // Mark `typeof require` and similar as a valid use of `require`
+  const argument = node.argument;
+  if (argument.type !== 'Identifier' || argument.name !== 'require')
+    return false;
+
+  if (this.requireUses.has(argument))
+    return false;
+  this.requireUses.add(argument);
+};
+
 Analyzer.prototype.siftRequireCall = function siftRequireCall(node, current) {
   const callee = node.callee;
   if (callee.type !== 'Identifier' || callee.name !== 'require')
@@ -493,10 +505,6 @@ Analyzer.prototype.siftRequireUse = function siftRequireUse(node, current) {
   if (this.requireUses.has(node))
     return;
   this.requireUses.add(node);
-
-  // No need to bail out on eg. `typeof require`
-  if (node.parentNode.type === 'UnaryExpression')
-    return;
 
   current.bailout('Invalid use of `require`', node.loc);
   this.bailout('Invalid use of `require`', node.loc, current.resource);

--- a/lib/shake/walk.js
+++ b/lib/shake/walk.js
@@ -14,14 +14,6 @@ module.exports = (node, visitors) => {
   !function c(node, st, override) {
     var type = override || node.type, found = visitors[type];
     if (found) found(node, st);
-    BASE[type](node, st, descend(node, c));
+    BASE[type](node, st, c);
   }(node, state, override);
-
-  // Add a `.parentNode` property to nodes during the walk.
-  function descend(node, c) {
-    return (child, st, override) => {
-      if (child !== node) child.parentNode = node;
-      c(child, st, override);
-    };
-  }
 };

--- a/lib/shake/walk.js
+++ b/lib/shake/walk.js
@@ -14,6 +14,14 @@ module.exports = (node, visitors) => {
   !function c(node, st, override) {
     var type = override || node.type, found = visitors[type];
     if (found) found(node, st);
-    BASE[type](node, st, c);
+    BASE[type](node, st, descend(node, c));
   }(node, state, override);
+
+  // Add a `.parentNode` property to nodes during the walk.
+  function descend(node, c) {
+    return (child, st, override) => {
+      if (child !== node) child.parentNode = node;
+      c(child, st, override);
+    };
+  }
 };

--- a/test/analyzer-test.js
+++ b/test/analyzer-test.js
@@ -383,6 +383,16 @@ describe('Analyzer', () => {
     ]);
   });
 
+  it('should not bailout on `typeof require`', () => {
+    analyzer.run(parse(`
+      if (typeof require === 'function') {
+        console.log("ok");
+      }
+    `), 'root');
+
+    assert.strictEqual(analyzer.getModule('root').getInfo().bailouts, false);
+  });
+
   it('should bailout on assignment to `module.exports`', () => {
     analyzer.run(parse(`
       module.exports = () => {};


### PR DESCRIPTION
Some modules use `typeof require === 'function'` for feature detection.
This would cause a global bailout because common-shake saw a `require`
in an unknown situation.
This case doesn't have any risk of including a module that we can't
statically determine in the bundle, so we can keep going.

To do this the walk() function now adds a `.parentNode` property to the
nodes as it walks the AST.