### PR TITLE
Dependent uses

### DIFF
--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -249,7 +249,8 @@ Analyzer.prototype.isExports = function isExports(node) {
 Analyzer.prototype.sift = function sift(ast, current) {
   walk(ast, {
     AssignmentExpression: node => this.siftAssignment(node, current),
-    MemberExpression: node => this.siftMember(node, current, false),
+    MemberExpression: (node, state, ancestors) =>
+      this.siftMember(node, current, false, ancestors),
     Identifier: node => this.siftRequireUse(node, current),
     CallExpression: node => this.siftCall(node, current),
     NewExpression: node => this.siftNew(node, current),
@@ -382,7 +383,8 @@ Analyzer.prototype.siftModuleExports = function siftModuleExports(node,
   }
 };
 
-Analyzer.prototype.siftMember = function siftMember(node, current, recursive) {
+Analyzer.prototype.siftMember = function siftMember(node, current, recursive,
+                                                    ancestors) {
   let module;
   if (this.isExports(node.object)) {
     // Do not track assignments twice
@@ -417,10 +419,25 @@ Analyzer.prototype.siftMember = function siftMember(node, current, recursive) {
     return;
   }
 
+  const dependsParent = ancestors && ancestors.find(parent => {
+    if (parent.type !== 'AssignmentExpression') return false;
+    if (parent.left.type !== 'MemberExpression') return false;
+    return this.isExports(parent.left.object);
+  });
+  const dependsNode = dependsParent && dependsParent.left.property;
+  const dependsProp = dependsNode && (dependsNode.name || dependsNode.value);
+
   // TODO(indutny): build dependency tree for self-uses. They should not retain
   // themselves or others if unused.
   const prop = node.property.name || node.property.value;
-  module.use(prop, current, recursive);
+
+  // Recursive call to an `exports.fn()`.
+  if (dependsProp === prop) {
+    this.exportsUses.add(dependsParent.left.object);
+    return;
+  }
+
+  module.use(prop, current, recursive, dependsProp);
 
   // For recursive imports
   return { module, property: prop };

--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -427,8 +427,6 @@ Analyzer.prototype.siftMember = function siftMember(node, current, recursive,
   const dependsNode = dependsParent && dependsParent.left.property;
   const dependsProp = dependsNode && (dependsNode.name || dependsNode.value);
 
-  // TODO(indutny): build dependency tree for self-uses. They should not retain
-  // themselves or others if unused.
   const prop = node.property.name || node.property.value;
 
   // Recursive call to an `exports.fn()`.

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -9,8 +9,10 @@ function Module(resource) {
   this.uses = new Map();
   this.declarations = [];
 
+  this.dependentUses = [];
   this.pendingUses = [];
   this.computing = false;
+  this.computingDependents = [];
   this.forced = false;
 }
 module.exports = Module;
@@ -32,6 +34,17 @@ Module.prototype.isUsed = function isUsed(name) {
     const pending = this.pendingUses.some(use => use.property === name);
     if (pending)
       return true;
+
+    const dependent = this.dependentUses.find(use => use.property === name);
+    // Make sure we don't hang on cycles, `exports.a` calling `exports.b`
+    // and vice versa.
+    if (dependent &&
+        this.computingDependents.indexOf(dependent.property) === -1) {
+      this.computingDependents.push(dependent.dependency);
+      const result = dependent.from.isUsed(dependent.dependency);
+      this.computingDependents.pop();
+      return result;
+    }
   }
 
   return this.uses.has(name);
@@ -67,7 +80,13 @@ Module.prototype.bailout = function bailout(reason, loc, source, level) {
   this.sealed = false;
 };
 
-Module.prototype.use = function use(property, from, recursive) {
+Module.prototype.use = function use(property, from, recursive, dependency) {
+  if (dependency !== undefined) {
+    debug('dependent use this=%j property=%j from=%j dependency=%j',
+          this.resource, property, from.resource, dependency);
+    this.dependentUses.push({ property, from, dependency });
+    return;
+  }
   if (recursive !== false) {
     debug('pending use this=%j property=%j from=%j recursive=%j',
           this.resource, property, from.resource, recursive);
@@ -136,7 +155,8 @@ Module.prototype.compute = function compute() {
   if (this.computing)
     return;
   this.computing = true;
-  debug('compute this=%j pending=%d', this.resource, this.pendingUses.length);
+  debug('compute this=%j pending=%d dependent=%d', this.resource,
+        this.pendingUses.length, this.dependentUses.length);
 
   // Do several passes until it will stabilize
   // TODO(indutny): what is complexity of this? Exponential?
@@ -155,6 +175,19 @@ Module.prototype.compute = function compute() {
 
   this.pendingUses.forEach(use => this.use(use.property, use.from, false));
 
+  do {
+    before = this.dependentUses.length;
+
+    this.dependentUses = this.dependentUses.filter((use) => {
+      return use.from.isUsed(use.dependency);
+    });
+    debug('compute dependent pass this=%j before=%d after=%d',
+          this.resource, before, this.dependentUses.length);
+  } while (this.dependentUses.length !== before);
+
+  this.dependentUses.forEach(use => this.use(use.property, use.from, false));
+
   this.pendingUses = null;
+  this.dependentUses = null;
   this.computing = false;
 };

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -12,7 +12,6 @@ function Module(resource) {
   this.dependentUses = [];
   this.pendingUses = [];
   this.computing = false;
-  this.computingDependents = [];
   this.forced = false;
 }
 module.exports = Module;
@@ -23,7 +22,7 @@ Module.prototype.forceExport = function forceExport() {
   this.forced = true;
 };
 
-Module.prototype.isUsed = function isUsed(name) {
+Module.prototype.isUsed = function isUsed(name, dependentStack) {
   this.compute();
 
   if (this.bailouts || this.forced)
@@ -36,13 +35,18 @@ Module.prototype.isUsed = function isUsed(name) {
       return true;
 
     const dependent = this.dependentUses.find(use => use.property === name);
-    // Make sure we don't hang on cycles, `exports.a` calling `exports.b`
-    // and vice versa.
-    if (dependent &&
-        this.computingDependents.indexOf(dependent.property) === -1) {
-      this.computingDependents.push(dependent.dependency);
-      const result = dependent.from.isUsed(dependent.dependency);
-      this.computingDependents.pop();
+    // Make sure we don't hang on recursive dependencies, `exports.a`
+    // calling `exports.b` and vice versa.
+    if (dependent && (dependentStack === undefined ||
+                      dependentStack.indexOf(dependent.property) === -1)) {
+      if (dependentStack === undefined) {
+        dependentStack = [dependent.dependency];
+      } else {
+        dependentStack.push(dependent.dependency);
+      }
+      const result = dependent.from.isUsed(dependent.dependency,
+                                           dependentStack);
+      dependentStack.pop();
       return result;
     }
   }
@@ -133,6 +137,7 @@ Module.prototype.mergeFrom = function mergeFrom(unresolved) {
   });
   unresolved.declarations.forEach(declaration => this.declare(declaration));
   this.pendingUses = this.pendingUses.concat(unresolved.pendingUses);
+  this.dependentUses = this.dependentUses.concat(unresolved.dependentUses);
 
   unresolved.clear();
 };
@@ -145,6 +150,7 @@ Module.prototype.clear = function clear() {
   this.uses = null;
   this.declarations = null;
   this.pendingUses = null;
+  this.dependentUses = null;
 };
 
 Module.prototype.compute = function compute() {
@@ -162,30 +168,27 @@ Module.prototype.compute = function compute() {
   // TODO(indutny): what is complexity of this? Exponential?
   let before;
   do {
-    before = this.pendingUses.length;
+    before = this.pendingUses.length + this.dependentUses.length;
 
     // NOTE: it is important to overwrite this, since recursive lookups will
     // get to it.
     this.pendingUses = this.pendingUses.filter((use) => {
       return use.from.isUsed(use.recursive);
     });
-    debug('compute pass this=%j before=%d after=%d',
-          this.resource, before, this.pendingUses.length);
-  } while (this.pendingUses.length !== before);
-
-  this.pendingUses.forEach(use => this.use(use.property, use.from, false));
-
-  do {
-    before = this.dependentUses.length;
-
     this.dependentUses = this.dependentUses.filter((use) => {
       return use.from.isUsed(use.dependency);
     });
-    debug('compute dependent pass this=%j before=%d after=%d',
-          this.resource, before, this.dependentUses.length);
-  } while (this.dependentUses.length !== before);
+    debug('compute pass this=%j before=%d after=%d',
+          this.resource, before,
+          this.pendingUses.length + this.dependentUses.length);
+  } while (this.pendingUses.length + this.dependentUses.length !== before);
 
-  this.dependentUses.forEach(use => this.use(use.property, use.from, false));
+  this.pendingUses.forEach(use => this.use(use.property, use.from, false));
+  this.dependentUses.forEach(use => {
+    debug('dependent mark used from=%j property=%j',
+          use.from.resource, use.property);
+    this.use(use.property, use.from, false);
+  });
 
   this.pendingUses = null;
   this.dependentUses = null;

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -168,20 +168,26 @@ Module.prototype.compute = function compute() {
   // TODO(indutny): what is complexity of this? Exponential?
   let before;
   do {
-    before = this.pendingUses.length + this.dependentUses.length;
+    before = this.pendingUses.length;
 
     // NOTE: it is important to overwrite this, since recursive lookups will
     // get to it.
     this.pendingUses = this.pendingUses.filter((use) => {
       return use.from.isUsed(use.recursive);
     });
+    debug('compute pass this=%j before=%d after=%d',
+          this.resource, before, this.pendingUses.length);
+  } while (this.pendingUses.length !== before);
+
+  do {
+    before = this.dependentUses.length;
+
     this.dependentUses = this.dependentUses.filter((use) => {
       return use.from.isUsed(use.dependency);
     });
-    debug('compute pass this=%j before=%d after=%d',
-          this.resource, before,
-          this.pendingUses.length + this.dependentUses.length);
-  } while (this.pendingUses.length + this.dependentUses.length !== before);
+    debug('compute pass (dependent) this=%j before=%d after=%d',
+          this.resource, before, this.dependentUses.length);
+  } while (this.dependentUses.length !== before);
 
   this.pendingUses.forEach(use => this.use(use.property, use.from, false));
   this.dependentUses.forEach(use => {

--- a/lib/shake/walk.js
+++ b/lib/shake/walk.js
@@ -11,9 +11,13 @@ const BASE = Object.assign({
 module.exports = (node, visitors) => {
   const state = null;
   const override = false;
+  const ancestors = [];
   !function c(node, st, override) {
     var type = override || node.type, found = visitors[type];
-    if (found) found(node, st);
+    const isNew = node != ancestors[ancestors.length - 1];
+    if (isNew) ancestors.push(node);
+    if (found) found(node, st, ancestors);
     BASE[type](node, st, c);
+    if (isNew) ancestors.pop();
   }(node, state, override);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,15 +2779,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
@@ -2813,6 +2804,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {


### PR DESCRIPTION
This patch adds dependency tracking to individual exports. If an export A is only used inside another exported function B that is not used, the A export will also be marked as unused.

To detect whether an export is used inside another export, I copied the `ancestor()` walker from Acorn, so the `siftMember` method can check if any of the ancestors of the current node also assign an export.

I added a parameter to `Module#isUsed()` when checking dependent uses, which tracks which dependencies have already been visited, to address recursive dependencies like:

```js
// a.js
exports.a = function () { return require('./b').b }
// b.js
exports.b = function () { return require('./a').a }
```

(Initially I used a `this.computingDependents` array for this purpose but that didn't work when a recursive dependency crossed module boundaries.)